### PR TITLE
cli: use yield_per when reindexing

### DIFF
--- a/invenio_workflows_ui/cli.py
+++ b/invenio_workflows_ui/cli.py
@@ -55,7 +55,7 @@ def reindex(yes_i_know, data_type):
 
     query = WorkflowObjectModel.query.filter(
         WorkflowObjectModel.data_type.in_(data_type)
-    )
+    ).yield_per(1000)
 
     with click.progressbar(query) as q:
         for result in q:


### PR DESCRIPTION
* This prevents using an excessive amount of memory.

Signed-off-by: David Caro <david@dcaro.es>