### PR TITLE
tasks: collect unexpected errors while indexing

### DIFF
--- a/invenio_workflows_ui/tasks.py
+++ b/invenio_workflows_ui/tasks.py
@@ -75,13 +75,21 @@ def batch_reindex(workflow_ids, request_timeout):
             except WorkflowsError as e:
                 LOGGER.warn('Workflow %s failed to load: %s', workflow_id, e)
 
-    success, failures = elasticsearch.helpers.bulk(
-        current_search_client,
-        actions(),
-        request_timeout=request_timeout,
-        raise_on_error=False,
-        raise_on_exception=False,
-    )
+    try:
+        success, failures = elasticsearch.helpers.bulk(
+            current_search_client,
+            actions(),
+            request_timeout=request_timeout,
+            raise_on_error=False,
+            raise_on_exception=False,
+        )
+    except Exception as e:
+        return {
+            'failures': [{
+                'error': repr(e),
+                'workflow_ids': workflow_ids,
+            }],
+        }
 
     return {
         'success': success,


### PR DESCRIPTION
- when an error happens during bulk reindex store error details in task result message